### PR TITLE
Add module-level docs to files and add all function Haddocks

### DIFF
--- a/src/Codec/Audio/Opus/Decoder/Conduit.hs
+++ b/src/Codec/Audio/Opus/Decoder/Conduit.hs
@@ -1,3 +1,4 @@
+-- | Conduit interface for decoding audio data with Opus.
 module Codec.Audio.Opus.Decoder.Conduit
   ( decoderC, decoderLazyC
   , decoderSink
@@ -11,21 +12,26 @@ import qualified Data.ByteString.Lazy     as BL
 import           Data.Conduit.Combinators
 import           Prelude                  (($))
 
+-- | Decode audio data with Opus.
 decoderC :: (HasDecoderStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString ByteString m ()
 decoderC cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
   \d -> mapM (opusDecode d cfg)
 
+-- | Decode lazy bytestring audio data with Opus.
 decoderLazyC :: (HasDecoderStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString BL.ByteString m ()
 decoderLazyC cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
   \d -> mapM (opusDecodeLazy d cfg)
 
+-- | A sink to decode audio data with Opus and return a lazy bytestring of the
+-- whole stream.
 decoderSink :: (HasDecoderStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString o m BL.ByteString
 decoderSink cfg = withDecoder (cfg ^. deStreamDecoderConfig) $
   \d -> foldMapM (opusDecodeLazy d cfg)
 
+-- | Run a conduit that uses a decoder with the given configuration.
 withDecoder :: (HasDecoderConfig cfg, MonadResource m) =>
   cfg -> (Decoder -> ConduitT i o m r) -> ConduitT i o m r
 withDecoder cfg = bracketP (opusDecoderCreate cfg) opusDecoderDestroy

--- a/src/Codec/Audio/Opus/Encoder/Conduit.hs
+++ b/src/Codec/Audio/Opus/Encoder/Conduit.hs
@@ -1,3 +1,4 @@
+-- | Conduit interface for encoding audio data with Opus.
 module Codec.Audio.Opus.Encoder.Conduit
   ( encoderC, encoderLazyC
   , encoderSink
@@ -11,21 +12,26 @@ import qualified Data.ByteString.Lazy     as BL
 import           Data.Conduit.Combinators
 import           Prelude                  (($))
 
+-- | Encode audio data with Opus.
 encoderC :: (HasStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString ByteString m ()
 encoderC cfg = withEncoder (cfg ^. streamConfig) $
   \e -> mapM (opusEncode e cfg)
 
+-- | Encode lazy bytestring audio data with Opus.
 encoderLazyC :: (HasStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString BL.ByteString m ()
 encoderLazyC cfg = withEncoder (cfg ^. streamConfig) $
   \e -> mapM (opusEncodeLazy e cfg)
 
+-- | A sink to encode audio data with Opus and return a lazy bytestring of the
+-- whole stream.
 encoderSink :: (HasStreamConfig cfg, MonadResource m) =>
   cfg -> ConduitT ByteString o m BL.ByteString
 encoderSink cfg = withEncoder (cfg ^. streamConfig) $
   \e -> foldMapM (opusEncodeLazy e cfg)
 
+-- | Run a conduit that uses an encoder with the given configuration.
 withEncoder :: (HasEncoderConfig cfg, MonadResource m) =>
   cfg -> (Encoder -> ConduitT i o m r) -> ConduitT i o m r
 withEncoder cfg = bracketP (opusEncoderCreate cfg) opusEncoderDestroy

--- a/src/Codec/Audio/Opus/Internal/Opus.hsc
+++ b/src/Codec/Audio/Opus/Internal/Opus.hsc
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP                      #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-
+-- | This module contains the raw FFI bindings to the Opus library. It is not
+-- meant to be consumed directly by users of this library, but rather to be
+-- used by the higher-level API in "Codec.Audio.Opus".
 module Codec.Audio.Opus.Internal.Opus where
 
 import           Foreign
@@ -9,15 +11,19 @@ import           Foreign.C.String
 
 #include <opus.h>
 
+-- | Raw error codes returned by the Opus library, represented as an int.
 newtype ErrorCode = ErrorCode { unErrorCode :: CInt }
-    deriving (Eq,Show)
+    deriving (Eq, Show)
 
+-- | Storable instance for 'ErrorCode' which is necessary for using it an
+-- argument in FFI calls.
 instance Storable ErrorCode where
   sizeOf (ErrorCode e) = sizeOf e
   alignment (ErrorCode e) = alignment e
   peek p = ErrorCode <$> peek (castPtr p)
   poke p = poke (castPtr p) . unErrorCode
 
+-- | A mapping of Haskell definitions of error codes to C counterparts.
 #{enum ErrorCode, ErrorCode
   , opus_ok               = OPUS_OK
   , opus_bad_arg          = OPUS_BAD_ARG
@@ -29,17 +35,11 @@ instance Storable ErrorCode where
   , opus_alloc_fail       = OPUS_ALLOC_FAIL
   }
 
-
+-- | Coding mode for the Opus encoder, represented as an int.
 newtype CodingMode = CodingMode { unCodingMode :: CInt }
     deriving (Eq)
 
-
-#{enum CodingMode, CodingMode
- , app_voip = OPUS_APPLICATION_VOIP
- , app_audio = OPUS_APPLICATION_AUDIO
- , app_lowdelay = OPUS_APPLICATION_RESTRICTED_LOWDELAY
- }
-
+-- | Show instance for 'CodingMode'.
 instance Show CodingMode where
   show a
     | app_voip == a = "voip coding"
@@ -47,83 +47,125 @@ instance Show CodingMode where
     | app_lowdelay == a = "lowdelay coding"
     | otherwise = "unknown coding"
 
-type OpusInt = Int32
+-- | A mapping of Haskell definitions of coding modes to C counterparts.
+#{enum CodingMode, CodingMode
+ , app_voip = OPUS_APPLICATION_VOIP
+ , app_audio = OPUS_APPLICATION_AUDIO
+ , app_lowdelay = OPUS_APPLICATION_RESTRICTED_LOWDELAY
+ }
 
+-- | Sampling rate for the Opus encoder, represented as an int.
 newtype SamplingRate = SamplingRate { unSamplingRate :: Int }
     deriving (Eq)
 
--- | sampling rate 8kHz
-opusSR8k :: SamplingRate
-opusSR8k = SamplingRate 8000
-
--- | sampling rate 12kHz
-opusSR12k :: SamplingRate
-opusSR12k = SamplingRate 12000
-
--- | sampling rate 16kHz
-opusSR16k :: SamplingRate
-opusSR16k = SamplingRate 16000
-
--- | sampling rate 24kHz
-opusSR24k :: SamplingRate
-opusSR24k = SamplingRate 24000
-
--- | sampling rate 48kHz
-opusSR48k :: SamplingRate
-opusSR48k = SamplingRate 48000
-
-
+-- | Show instance for 'SamplingRate' makes it human-readable.
 instance Show SamplingRate where
   show (SamplingRate r) = mconcat [show $ r `div` 1000, "kHz"]
 
+-- | Sampling rate 8kHz
+opusSR8k :: SamplingRate
+opusSR8k = SamplingRate 8000
+
+-- | Sampling rate 12kHz
+opusSR12k :: SamplingRate
+opusSR12k = SamplingRate 12000
+
+-- | Sampling rate 16kHz
+opusSR16k :: SamplingRate
+opusSR16k = SamplingRate 16000
+
+-- | Sampling rate 24kHz
+opusSR24k :: SamplingRate
+opusSR24k = SamplingRate 24000
+
+-- | Sampling rate 48kHz
+opusSR48k :: SamplingRate
+opusSR48k = SamplingRate 48000
+
+-- Declare empty (i.e. opaque) data types for the encoder and decoder states.
+-- This is not meant to be consumed by Haskell code, but is rather meant to
+-- encapsulate the C types that FFI calls return and expect to be passed
+-- modified in a subsequent FFI call.
+--
+-- For example, the encoder state can be created only by 'c_opus_encoder_create',
+-- and destroyed by 'cp_opus_encoder_destroy'.
+
+-- | Encoder state. Can be created only by 'c_opus_encoder_create',
+-- and destroyed by 'cp_opus_encoder_destroy'.
 data EncoderT
+
+-- | Decoder state. Can be created only by 'c_opus_decoder_create',
+-- and destroyed by 'cp_opus_decoder_destroy'.
 data DecoderT
 
 
--- | allocates and initializes an encoder state.
+-- | Allocates and initializes an encoder state.
 foreign import ccall unsafe "opus.h opus_encoder_create"
     c_opus_encoder_create
-      :: SamplingRate -- ^ sampling rate of input signal (Hz) This must be one of 8000, 12000, 16000, 24000, or 48000.
-      -> Int32    -- ^ Number of channels (1 or 2) in input signal
-      -> CodingMode -- ^ Coding mode. (See 'app_voip', 'app_audio', 'app_lowdelay')
-      -> Ptr ErrorCode -- ^ 'ErrorCode' pointer
+      :: SamplingRate
+      -- ^ Sampling rate of input signal (Hz).
+      -> Int32
+      -- ^ Number of channels (1 or 2) in input signal
+      -> CodingMode
+      -- ^ Coding mode. (See 'app_voip', 'app_audio', 'app_lowdelay')
+      -> Ptr ErrorCode
+      -- ^ 'ErrorCode' pointer
       -> IO (Ptr EncoderT)
 
--- | Frees an 'EncoderT'
+-- | Frees an 'EncoderT' that has been created using 'c_opus_encoder_create'.
 foreign import ccall unsafe "opus.h &opus_encoder_destroy"
     cp_opus_encoder_destroy
       :: FunPtr (Ptr EncoderT -> IO ())
 
-
+-- | Encode an Opus frame.
 foreign import ccall unsafe "opus.h opus_encode"
     c_opus_encode
-      :: Ptr EncoderT  -- ^ encoder state
-      -> Ptr CShort    -- ^ input signal
-      -> Int32         -- ^ frame size
-      -> CString       -- ^ output payload
-      -> Int32         -- ^ max data bytes
-      -> IO Int32      -- ^ number of bytes written or negative in case of error
+      :: Ptr EncoderT
+      -- ^ Encoder state
+      -> Ptr CShort
+      -- ^ Input signal
+      -> Int32
+      -- ^ Frame size
+      -> CString
+      -- ^ Output payload
+      -> Int32
+      -- ^ Max data bytes
+      -> IO Int32
+      -- ^ Number of bytes written or negative in case of error
 
--- | allocates and initializes a decoder state.
+-- | Allocates and initializes a decoder state.
 foreign import ccall unsafe "opus.h opus_decoder_create"
     c_opus_decoder_create
-      :: SamplingRate -- ^ sampling rate, same as encoder_create
-      -> Int32 -- ^ Number of channels in input signal
-      -> Ptr ErrorCode -- ^ 'ErrorCode' pointer
+      :: SamplingRate
+      -- ^ Sampling rate, same as encoder_create
+      -> Int32
+      -- ^ Number of channels in input signal
+      -> Ptr ErrorCode
+      -- ^ 'ErrorCode' pointer
       -> IO (Ptr DecoderT)
 
--- | Frees a 'DecoderT'
+-- | Frees a 'DecoderT' that has been created using 'c_opus_decoder_create'.
 foreign import ccall unsafe "opus.h &opus_decoder_destroy"
     cp_opus_decoder_destroy
       :: FunPtr (Ptr DecoderT -> IO ())
 
+-- | Decodes an Opus frame.
 foreign import ccall unsafe "opus.h opus_decode"
     c_opus_decode
-      :: Ptr DecoderT -- ^ Decoder state
-      -> Ptr CChar    -- ^ Byte array of compressed data
-      -> Int32        -- ^ Exact number of bytes in the payload
-      -> Ptr CShort   -- ^ decoded audio data
-      -> Int32        -- ^ max duration of the frame in samples that can fit
-      -> CInt         -- ^ flag to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.
-      -> IO Int32     -- ^ Number of decoded samples, or negative in case of error
+      :: Ptr DecoderT
+      -- ^ Decoder state
+      -> Ptr CChar
+      -- ^ Byte array of compressed data
+      -> Int32
+      -- ^ Exact number of bytes in the payload
+      -> Ptr CShort
+      -- ^ Decoded audio data
+      -> Int32
+      -- ^ Max duration of the frame in samples that can fit
+      -> CInt
+      -- ^ Flag to request that any in-band forward error correction data be
+      -- decoded. If no such data is available, the frame is decoded as if it
+      -- were lost.
+      -> IO Int32
+      -- ^ Number of decoded samples, or negative in case of error
 

--- a/src/Codec/Audio/Opus/Internal/Opus.hsc
+++ b/src/Codec/Audio/Opus/Internal/Opus.hsc
@@ -23,17 +23,37 @@ instance Storable ErrorCode where
   peek p = ErrorCode <$> peek (castPtr p)
   poke p = poke (castPtr p) . unErrorCode
 
--- | A mapping of Haskell definitions of error codes to C counterparts.
-#{enum ErrorCode, ErrorCode
-  , opus_ok               = OPUS_OK
-  , opus_bad_arg          = OPUS_BAD_ARG
-  , opus_buffer_too_small = OPUS_BUFFER_TOO_SMALL
-  , opus_internal_error   = OPUS_INTERNAL_ERROR
-  , opus_invalid_packet   = OPUS_INVALID_PACKET
-  , opus_unimplemented    = OPUS_UNIMPLEMENTED
-  , opus_invalid_state    = OPUS_INVALID_STATE
-  , opus_alloc_fail       = OPUS_ALLOC_FAIL
-  }
+-- | libopus error: No error.
+opus_ok :: ErrorCode
+opus_ok = ErrorCode (#const OPUS_OK)
+
+-- | libopus error: One or more invalid/out of range arguments.
+opus_bad_arg :: ErrorCode
+opus_bad_arg = ErrorCode (#const OPUS_BAD_ARG)
+
+-- | libopus error: Not enough bytes allocated in the buffer.
+opus_buffer_too_small :: ErrorCode
+opus_buffer_too_small = ErrorCode (#const OPUS_BUFFER_TOO_SMALL)
+
+-- | libopus error: An internal error was detected.
+opus_internal_error :: ErrorCode
+opus_internal_error = ErrorCode (#const OPUS_INTERNAL_ERROR)
+
+-- | libopus error: The compressed data passed is corrupted.
+opus_invalid_packet :: ErrorCode
+opus_invalid_packet = ErrorCode (#const OPUS_INVALID_PACKET)
+
+-- | libopus error: Invalid/unsupported request number.
+opus_unimplemented :: ErrorCode
+opus_unimplemented = ErrorCode (#const OPUS_UNIMPLEMENTED)
+
+-- | libopus error: An encoder or decoder structure is invalid or already freed.
+opus_invalid_state :: ErrorCode
+opus_invalid_state = ErrorCode (#const OPUS_INVALID_STATE)
+
+-- | libopus error: Memory allocation has failed.
+opus_alloc_fail :: ErrorCode
+opus_alloc_fail = ErrorCode (#const OPUS_ALLOC_FAIL)
 
 -- | Coding mode for the Opus encoder, represented as an int.
 newtype CodingMode = CodingMode { unCodingMode :: CInt }
@@ -47,12 +67,19 @@ instance Show CodingMode where
     | app_lowdelay == a = "lowdelay coding"
     | otherwise = "unknown coding"
 
--- | A mapping of Haskell definitions of coding modes to C counterparts.
-#{enum CodingMode, CodingMode
- , app_voip = OPUS_APPLICATION_VOIP
- , app_audio = OPUS_APPLICATION_AUDIO
- , app_lowdelay = OPUS_APPLICATION_RESTRICTED_LOWDELAY
- }
+-- | Best for most VoIP/videoconference applications where listening quality and
+-- intelligibility matter most.
+app_voip :: CodingMode
+app_voip = CodingMode (#const OPUS_APPLICATION_VOIP)
+
+-- | Best for broadcast/high-fidelity application where the decoded audio should
+-- be as close as possible to the input.
+app_audio :: CodingMode
+app_audio = CodingMode (#const OPUS_APPLICATION_AUDIO)
+
+-- | Only use when lowest-achievable latency is what matters most.
+app_lowdelay :: CodingMode
+app_lowdelay = CodingMode (#const OPUS_APPLICATION_RESTRICTED_LOWDELAY)
 
 -- | Sampling rate for the Opus encoder, represented as an int.
 newtype SamplingRate = SamplingRate { unSamplingRate :: Int }

--- a/src/Codec/Audio/Opus/Types.hs
+++ b/src/Codec/Audio/Opus/Types.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
-
+-- | This module contains the types used in the higher-level API of this library.
 module Codec.Audio.Opus.Types
  ( -- * Sampling Rate
    SamplingRate, HasSamplingRate(..)
@@ -27,23 +27,36 @@ import           Control.Monad.Catch
 import           Data.Typeable                  (Typeable)
 
 
+-- | A potential error that can happen during encoding or decoding, as reported
+-- by the Opus library. The descriptions of each error have been taken from the
+-- [Opus documentation](https://opus-codec.org/docs/opus_api-1.5/group__opus__errorcodes.html).
 data OpusException
   = OpusBadArg
+  -- ^ One or more invalid/out of range arguments.
   | OpusBufferToSmall
+  -- ^ Not enough bytes allocated in the buffer.
   | OpusInternalError
+  -- ^ An internal error was detected.
   | OpusInvalidPacket
+  -- ^ The compressed data passed is corrupted.
   | OpusUnimplemented
+  -- ^ Invalid/unsupported request number.
   | OpusInvalidState
+  -- ^ An encoder or decoder structure is invalid or already freed.
   | OpusAllocFail
+  -- ^ Memory allocation has failed.
   deriving (Eq, Show, Typeable)
 
 instance Exception OpusException
 
+-- | A 'Traversal' that maps a function @f@ onto the contained 'OpusException'
+-- if the input 'ErrorCode' can be converted into it.
 _ErrorCodeException :: Traversal' ErrorCode OpusException
 _ErrorCodeException f e
   | Just exc <- errorCodeException e = errorCodeException' <$> f exc
   | otherwise = pure e
 
+-- | Convert an 'OpusException' into an 'ErrorCode'.
 errorCodeException' :: OpusException -> ErrorCode
 errorCodeException' OpusBadArg        = opus_bad_arg
 errorCodeException' OpusBufferToSmall = opus_buffer_too_small
@@ -53,7 +66,8 @@ errorCodeException' OpusUnimplemented = opus_unimplemented
 errorCodeException' OpusInvalidState  = opus_invalid_state
 errorCodeException' OpusAllocFail     = opus_alloc_fail
 
-
+-- | Convert an 'ErrorCode' into an 'OpusException'. Returns Nothing if it is
+-- not a known error code.
 errorCodeException :: ErrorCode -> Maybe OpusException
 errorCodeException a
   | a == opus_bad_arg = Just OpusBadArg
@@ -66,76 +80,129 @@ errorCodeException a
   | otherwise = Nothing
 
 
+-- | A 'HasSamplingRate' typeclass, generated from the definition of
+-- 'SamplingRate' using Template Haskell. This allows us to use 'samplingRate'
+-- to access the 'SamplingRate' field of a data type such as 'EncoderConfig'.
 makeClassy ''SamplingRate
+
+-- | A 'HasCodingMode' typeclass, generated from the definition of 'CodingMode'
+-- using Template Haskell. This allows us to use 'codingMode' to access the
+-- 'CodingMode' field of a data type such as 'EncoderConfig'.
 makeClassy ''CodingMode
 
+-- | The configuration of an Opus encoder. Use 'mkEncoderConfig' to create a new
+-- 'EncoderConfig'.
 data EncoderConfig = EncoderConfig
-  { _encoderSamplingRate :: SamplingRate  -- ^ sampling rate of input signal
-  , _encoderIsStereo     :: Bool -- ^ stereo mode? ('True' => 2 channels, 'False' => 1 channel)
-  , _encoderCodingMode   :: CodingMode    -- ^ Coding mode. (See 'app_voip', 'app_audio', 'app_lowdelay')
+  { _encoderSamplingRate :: SamplingRate
+  -- ^ sampling rate of input signal
+  , _encoderIsStereo     :: Bool
+  -- ^ stereo mode? ('True' => 2 channels, 'False' => 1 channel)
+  , _encoderCodingMode   :: CodingMode
+  -- ^ Coding mode. (See 'app_voip', 'app_audio', 'app_lowdelay')
   } deriving (Eq, Show)
 
+-- | A 'HasEncoderConfig' typeclass, generated from the definition of
+-- 'EncoderConfig' using Template Haskell. This allows us to use 'encoderConfig'
+-- to access the 'EncoderConfig' field of e.g. 'StreamConfig'.
 makeClassy 'EncoderConfig
 
+-- | Create a new 'EncoderConfig' with the given sampling rate, stereo mode, and
+-- coding mode. Set the second argument to True for stereo mode, and False for
+-- mono mode.
 mkEncoderConfig :: SamplingRate -> Bool -> CodingMode -> EncoderConfig
 mkEncoderConfig = EncoderConfig
 
+-- | An 'EncoderConfig' has a reference to the 'SamplingRate' it is meant to be
+-- used with.
 instance HasSamplingRate EncoderConfig where
   samplingRate = encoderSamplingRate
 
+-- | An 'EncoderConfig' has a reference to the 'CodingMode' it is meant to be
+-- used with.
 instance HasCodingMode EncoderConfig where
   codingMode = encoderCodingMode
 
+-- | The configuration of an Opus decoder. Use 'mkDecoderConfig' to create a new
+-- 'DecoderConfig'.
 data DecoderConfig = DecoderConfig
   { _decoderSamplingRate :: SamplingRate
   , _decoderIsStereo     :: Bool
   } deriving (Eq, Show)
 
+-- | A 'HasDecoderConfig' typeclass, generated from the definition of
+-- 'DecoderConfig' using Template Haskell. This allows us to use 'decoderConfig'
+-- to access the 'DecoderConfig' field of e.g. 'DecoderStreamConfig'.
 makeClassy 'DecoderConfig
 
+-- | Create a new 'DecoderConfig' with the given sampling rate and stereo mode.
+-- Set the second argument to True for stereo mode, and False for mono mode.
 mkDecoderConfig :: SamplingRate -> Bool -> DecoderConfig
 mkDecoderConfig = DecoderConfig
 
+-- | A 'DecoderConfig' has a reference to the 'SamplingRate' it is meant to be
+-- used with.
 instance HasSamplingRate DecoderConfig where
   samplingRate = decoderSamplingRate
 
+-- | A type alias for the size of an Opus frame in integers.
 type FrameSize = Int
 
-
+-- | The configuration of an Opus encoder stream. Use 'mkStreamConfig' to
+-- create a new 'StreamConfig'.
 data StreamConfig = StreamConfig
   { _streamEncoderConfig :: EncoderConfig
   , _streamFrameSize     :: FrameSize
   , _streamOutSize       :: Int
   } deriving (Eq, Show)
 
+-- | A 'HasStreamConfig' typeclass, generated from the definition of
+-- 'StreamConfig' using Template Haskell.
 makeClassy ''StreamConfig
 
+-- | Create a new 'StreamConfig' with the given 'EncoderConfig', frame size, and
+-- output size.
 mkStreamConfig :: EncoderConfig -> FrameSize -> Int -> StreamConfig
 mkStreamConfig = StreamConfig
 
+-- | An 'StreamConfig' has a reference to the 'EncoderConfig' it was created
+-- with.
 instance HasEncoderConfig StreamConfig where
   encoderConfig = streamEncoderConfig
 
+-- | An 'StreamConfig' has a reference to the 'SamplingRate' it is meant to be
+-- used with.
 instance HasSamplingRate StreamConfig where
   samplingRate = encoderConfig . samplingRate
 
+-- | An 'StreamConfig' has a reference to the 'CodingMode' it is meant to be
+-- used with.
 instance HasCodingMode StreamConfig where
   codingMode = encoderConfig . codingMode
 
+-- | The configuration of an Opus decoder stream. Use 'mkDecoderStreamConfig' to
+-- create a new 'DecoderStreamConfig'.
 data DecoderStreamConfig = DecoderStreamConfig
   { _deStreamDecoderConfig :: DecoderConfig
   , _deStreamFrameSize     :: FrameSize
   , _deStreamDecodeFec     :: Int
   } deriving (Eq, Show)
 
+-- | A 'HasDecoderStreamConfig' typeclass, generated from the definition of
+-- 'DecoderStreamConfig' using Template Haskell.
 makeClassy ''DecoderStreamConfig
 
+-- | Create a new 'DecoderStreamConfig' with the given 'DecoderConfig', frame
+-- size, and FEC decode flag.
 mkDecoderStreamConfig :: DecoderConfig -> FrameSize -> Int -> DecoderStreamConfig
 mkDecoderStreamConfig = DecoderStreamConfig
 
+-- | A 'DecoderStreamConfig' has a reference to the 'DecoderConfig' it was
+-- created with.
 instance HasDecoderConfig DecoderStreamConfig where
     decoderConfig = deStreamDecoderConfig
 
+-- | A 'DecoderStreamConfig' has a reference to the 'SamplingRate' it is meant
+-- to be used with.
 instance HasSamplingRate DecoderStreamConfig where
     samplingRate = decoderConfig . samplingRate
 


### PR DESCRIPTION
- Adds module-level descriptions for each module
- Adds function- and value- Haddocks for 100% coverage
- Formats argument Haddocks consistently on a new line
- (Move away from using the #{enum} construct for hsc2hs as it doesn't allow writing Haddocks for individual items)