### PR TITLE
Add explicit dependency bounds and prepare for release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,17 +1,19 @@
 # ChangeLog for `opus`
 
-## Unreleased Changes
+### Unreleased Changes
 
-## 0.3.0.0
+- nothing yet!
 
-- [breaking] Update Cabal package description file schema to 3.0 (can no longer run with low Cabal versions)
-- [breaking] Use opus.h for includes instead of opus/opus.h for better Windows/Mingw compatibility
-- [breaking] Use pkg-config on all platforms including Windows
+### 0.3.0.0 — 2025 February
+
+- **[breaking]** Update Cabal package description file schema to 3.0 (can no longer run with low Cabal versions)
+- **[breaking]** Use opus.h for includes instead of opus/opus.h for better Windows/Mingw compatibility
+- **[breaking]** Use pkg-config on all platforms including Windows
 - Add CI to run tests on every pull request on GitHub
 - Modify test suite to remove dependency on `opus-tools` package (instead we now FFI into a local opus_compare.c)
 - Add Haddock documentation to all modules, values, and functions.
 
-## 0.2.1.0
+### 0.2.1.0 — 2025 February
 
 - Remove stack from project as Cabal is enough and reduces complexity
 - Received permission from alios (the original author) to release this package under the original name
@@ -19,13 +21,13 @@
 - Remove `hspec` from library dependency
 - Fix wrong include path for opus.h in hsc file (on Windows)
 
-## 0.2.0.0
+### 0.2.0.0 — 2022 May
 
 - Decoder and decoder conduit implemented
 - `opus` is forked from alios (the original author) due to inactivity
 - Add a test suite for decoding mono and stereo audio
 - Migrate from `lens` to `microlens` for lighter dependency
 
-## 0.1.0.0
+### 0.1.0.0 — 2018 July
 
 - Encoder and encoder conduit implemented

--- a/opus.cabal
+++ b/opus.cabal
@@ -37,10 +37,11 @@ copyright:           Markus Barenhoff <mbarenh@alios.org>, Yuto Takano <moa17sto
 category:            Codec
 build-type:          Simple
 tested-with:         GHC ==9.4.8
-extra-source-files:
+extra-doc-files:
     README.md
     ChangeLog.md
     LICENSE
+extra-source-files:
     test/opus_compare_wrapper.c
     test/opus_compare.c
 

--- a/opus.cabal
+++ b/opus.cabal
@@ -62,12 +62,12 @@ library
   pkgconfig-depends:   opus
   ghc-options:         -Wall
   build-depends:       base >= 4.7 && < 5,
-                       exceptions,
-                       resourcet,
-                       bytestring,
-                       conduit,
-                       microlens,
-                       microlens-th
+                       exceptions >= 0.10.0 && < 0.11,
+                       resourcet >= 1.2.1 && < 1.4,
+                       bytestring >= 0.11.0.0 && < 0.13,
+                       conduit >= 1.3 && < 1.4,
+                       microlens >= 0.4.11.2 && < 0.5,
+                       microlens-th >= 0.4.3.11 && < 0.5,
 
 test-suite opus-test
   type: exitcode-stdio-1.0

--- a/opus.cabal
+++ b/opus.cabal
@@ -40,6 +40,7 @@ tested-with:         GHC ==9.4.8
 extra-source-files:
     README.md
     ChangeLog.md
+    LICENSE
     test/opus_compare_wrapper.c
     test/opus_compare.c
 


### PR DESCRIPTION
- [x] `cabal check` has no errors