### PR TITLE
Add GHC 9.6 to officially supported GHC version list

### DIFF
--- a/opus.cabal
+++ b/opus.cabal
@@ -31,6 +31,7 @@ copyright:           Markus Barenhoff <mbarenh@alios.org>, Yuto Takano <moa17sto
 category:            Codec
 build-type:          Simple
 tested-with:         GHC ==9.4.8
+                   , GHC ==9.6.7
 extra-doc-files:
     README.md
     ChangeLog.md


### PR DESCRIPTION
We won't be making a new revision on Hackage since the existing version works as-is.